### PR TITLE
Fix compile issue with newer version of glibc

### DIFF
--- a/elf-parser.c
+++ b/elf-parser.c
@@ -389,7 +389,7 @@ void save_text_section64(int32_t fd, Elf64_Ehdr eh, Elf64_Shdr sh_table[])
 		goto EXIT;
 	}
 	assert(read(fd, buf, sh_table[i].sh_size)==sh_table[i].sh_size);
-	fd2 = open(pwd, O_RDWR|O_SYNC|O_CREAT);
+	fd2 = open(pwd, O_RDWR|O_SYNC|O_CREAT, 0644);
 	write(fd2, buf, sh_table[i].sh_size);
 	fsync(fd2);
 
@@ -786,7 +786,7 @@ void save_text_section(int32_t fd, Elf32_Ehdr eh, Elf32_Shdr sh_table[])
 		goto EXIT;
 	}
 	assert(read(fd, buf, sh_table[i].sh_size)==sh_table[i].sh_size);
-	fd2 = open(pwd, O_RDWR|O_SYNC|O_CREAT);
+	fd2 = open(pwd, O_RDWR|O_SYNC|O_CREAT, 0644);
 	write(fd2, buf, sh_table[i].sh_size);
 	fsync(fd2);
 


### PR DESCRIPTION
Newer versions of glibc and gcc will detect that the `open` function with the `O_CREAT` flag requires the mode argument be present:
```
Error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
```
I've added that third argument here.  I assume we want "read/write" for user/owner and just "read" for other.  Let me know if you want a different permission.