### PR TITLE
add missing include_directories to declare_dependeycy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ pkgconfig.generate(
   description : 'A library for parsing elf files')
 
 libelfparser_dep = declare_dependency(
+  include_directories : include_directories('.'),
   link_with : libelfparser,
 )
 


### PR DESCRIPTION
A fix to the meson file when using this project as a meson subproject dependency.